### PR TITLE
Add support for fetching `media_metadata` and `gallery_data`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bocanada/go-reddit/v2
+module github.com/bocanada/go-reddit/v3
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vartanbeno/go-reddit/v2
+module github.com/bocanada/go-reddit/v2
 
 go 1.15
 

--- a/reddit/live-thread_test.go
+++ b/reddit/live-thread_test.go
@@ -114,6 +114,7 @@ var expectedLiveThreadDiscussions = []*Post{
 		URL:       "https://www.reddit.com/live/15nfp4mtfbo14/",
 
 		Title: "test title",
+		Media: Media{Type: "liveupdate", OEmbed: OEmbed{}},
 
 		Score:            22,
 		UpvoteRatio:      0.9,
@@ -138,6 +139,7 @@ var expectedLiveThreadDiscussions = []*Post{
 
 		Title: "test title",
 
+		Media:            Media{Type: "liveupdate", OEmbed: OEmbed{}},
 		Score:            71,
 		UpvoteRatio:      0.97,
 		NumberOfComments: 34,

--- a/reddit/reddit-options.go
+++ b/reddit/reddit-options.go
@@ -21,6 +21,13 @@ func WithHTTPClient(httpClient *http.Client) Opt {
 	}
 }
 
+// WithRawJSON sets the query `raw_json` to `1`.
+// This allows the parsing of &lt;, &gt;, and &amp; as <, > and & respectively.
+func WithRawJSON(c *Client) error {
+	c.rawJSON = true
+	return nil
+}
+
 // WithUserAgent sets the User-Agent header for requests made with the client.
 // Reddit recommends the following format for the user agent:
 // <platform>:<app ID>:<version string> (by /u/<reddit username>)

--- a/reddit/reddit.go
+++ b/reddit/reddit.go
@@ -526,6 +526,9 @@ type ListOptions struct {
 	// Generally, the default is 25 and max is 100.
 	Limit int `url:"limit,omitempty"`
 
+	// TODO: Find a better place for this to live in.
+	RawJson int `url:"raw_json,omitempty"`
+
 	// The full ID of an item in the listing to use
 	// as the anchor point of the list. Only items
 	// appearing after it will be returned.

--- a/reddit/reddit.go
+++ b/reddit/reddit.go
@@ -244,6 +244,10 @@ func (c *Client) UserAgent() string {
 // The path is the relative URL which will be resolved to the BaseURL of the Client.
 // It should always be specified without a preceding slash.
 func (c *Client) NewRequest(method string, path string, form url.Values) (*http.Request, error) {
+	path, err := addRawJSONQuery(path, c.rawJSON)
+	if err != nil {
+		return nil, err
+	}
 	u, err := c.BaseURL.Parse(path)
 	if err != nil {
 		return nil, err
@@ -507,8 +511,7 @@ func addRawJSONQuery(path string, add bool) (string, error) {
 // A lot of Reddit's responses return a "thing": { "kind": "...", "data": {...} }
 // So this is just a nice convenient method to have.
 func (c *Client) getThing(ctx context.Context, path string, opts interface{}) (*thing, *Response, error) {
-	path, err := addRawJSONQuery(path, c.rawJSON) // if c.rawJSON == true, add "raw_json" to query, else path unmodified.
-	path, err = addOptions(path, opts)
+	path, err := addOptions(path, opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/reddit/stream.go
+++ b/reddit/stream.go
@@ -23,6 +23,7 @@ func (s *StreamService) Posts(subreddit string, opts ...StreamOpt) (<-chan *Post
 		Interval:       defaultStreamInterval,
 		DiscardInitial: false,
 		MaxRequests:    0,
+		Ctx:            context.Background(),
 	}
 	for _, opt := range opts {
 		opt(streamConfig)
@@ -40,18 +41,28 @@ func (s *StreamService) Posts(subreddit string, opts ...StreamOpt) (<-chan *Post
 			close(errsCh)
 		})
 	}
+	ctx, cancel := context.WithCancel(streamConfig.Ctx)
 
 	// originally used the "before" parameter, but if that post gets deleted, subsequent requests
 	// would just return empty listings; easier to just keep track of all post ids encountered
 	ids := set{}
 
 	go func() {
+		defer cancel()
 		defer stop()
 
 		var n int
 		infinite := streamConfig.MaxRequests == 0
 
 		for ; ; <-ticker.C {
+
+			// Check if the context was cancelled
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
 			n++
 
 			posts, err := s.getPosts(subreddit)
@@ -78,7 +89,13 @@ func (s *StreamService) Posts(subreddit string, opts ...StreamOpt) (<-chan *Post
 					break
 				}
 
-				postsCh <- post
+				// Check if the context was cancelled before sending posts to postsCh
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					postsCh <- post
+				}
 			}
 
 			if !infinite && n >= streamConfig.MaxRequests {
@@ -87,7 +104,7 @@ func (s *StreamService) Posts(subreddit string, opts ...StreamOpt) (<-chan *Post
 		}
 	}()
 
-	return postsCh, errsCh, stop
+	return postsCh, errsCh, cancel
 }
 
 func (s *StreamService) getPosts(subreddit string) ([]*Post, error) {

--- a/reddit/stream.go
+++ b/reddit/stream.go
@@ -74,6 +74,14 @@ func (s *StreamService) Posts(subreddit string, opts ...StreamOpt) (<-chan *Post
 				continue
 			}
 
+			if streamConfig.DiscardInitial {
+				for _, post := range posts {
+					id := post.FullID
+					ids.Add(id)
+				}
+				streamConfig.DiscardInitial = false
+			}
+
 			for _, post := range posts {
 				id := post.FullID
 
@@ -84,12 +92,7 @@ func (s *StreamService) Posts(subreddit string, opts ...StreamOpt) (<-chan *Post
 				}
 				ids.Add(id)
 
-				if streamConfig.DiscardInitial {
-					streamConfig.DiscardInitial = false
-					break
-				}
-
-				// Check if the context was cancelled before sending posts to postsCh
+				// Check if the context is done before sending posts to postsCh
 				select {
 				case <-ctx.Done():
 					return

--- a/reddit/streamer.go
+++ b/reddit/streamer.go
@@ -1,6 +1,9 @@
 package reddit
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 const defaultStreamInterval = time.Second * 5
 
@@ -8,6 +11,7 @@ type streamConfig struct {
 	Interval       time.Duration
 	DiscardInitial bool
 	MaxRequests    int
+	Ctx            context.Context
 }
 
 // StreamOpt is a configuration option to configure a stream.
@@ -35,6 +39,14 @@ func StreamMaxRequests(v int) StreamOpt {
 		if v > 0 {
 			c.MaxRequests = v
 		}
+	}
+}
+
+// StreamMaxRequests sets a limit on the number of times data is fetched for a stream.
+// If less than or equal to 0, it is assumed to be infinite.
+func StreamWithContext(ctx context.Context) StreamOpt {
+	return func(c *streamConfig) {
+		c.Ctx = ctx
 	}
 }
 

--- a/reddit/streamer.go
+++ b/reddit/streamer.go
@@ -42,8 +42,8 @@ func StreamMaxRequests(v int) StreamOpt {
 	}
 }
 
-// StreamMaxRequests sets a limit on the number of times data is fetched for a stream.
-// If less than or equal to 0, it is assumed to be infinite.
+// StreamWithContext adds a context to the Stream.
+// It can be used to cancel the stream.
 func StreamWithContext(ctx context.Context) StreamOpt {
 	return func(c *streamConfig) {
 		c.Ctx = ctx

--- a/reddit/subreddit_test.go
+++ b/reddit/subreddit_test.go
@@ -163,8 +163,8 @@ var expectedSearchPosts = []*Post{
 		Permalink: "/r/WatchPeopleDieInside/comments/hybow9/pregnancy_test/",
 		URL:       "https://v.redd.it/ra4qnt8bt8d51",
 
-		Title: "Pregnancy test",
-
+		Title:            "Pregnancy test",
+		Media:            Media{},
 		Score:            103829,
 		UpvoteRatio:      0.88,
 		NumberOfComments: 3748,

--- a/reddit/things.go
+++ b/reddit/things.go
@@ -560,10 +560,24 @@ type OEmbed struct {
 	ThumbnailHeight int    `json:"thumbnail_height,omitempty"`
 }
 
+type RedditVideoPreview struct {
+	BitrateKbps       int    `json:"bitrate_kbps,omitempty"`
+	DashURL           string `json:"dash_url,omitempty"`
+	Duration          int    `json:"duration,omitempty"`
+	FallbackURL       string `json:"fallback_url,omitempty"`
+	Height            int    `json:"height,omitempty"`
+	Width             int    `json:"width,omitempty"`
+	HlsURL            string `json:"hls_url,omitempty"`
+	IsGif             bool   `json:"is_gif,omitempty"`
+	ScrubberMediaUrl  string `json:"scrubber_media_url,omitempty"`
+	TranscodingStatus string `json:"transcoding_status,omitempty"`
+}
+
 // Media holds all the media metadata.
 type Media struct {
-	Type   string `json:"type,omitempty"`
-	OEmbed OEmbed `json:"oembed,omitempty"`
+	Type        string             `json:"type,omitempty"`
+	OEmbed      OEmbed             `json:"oembed,omitempty"`
+	RedditVideo RedditVideoPreview `json:"reddit_video,omitempty"`
 }
 
 // MediaMetadata is the media metadata of a Post.

--- a/reddit/things.go
+++ b/reddit/things.go
@@ -547,6 +547,28 @@ type MediaData struct {
 	Status string            `json:"status"`
 }
 
+// OEmbed holds all the embedded media data.
+type OEmbed struct {
+	ProviderURL     string `json:"provider_url,omitempty"`
+	Version         string `json:"version,omitempty"`
+	Title           string `json:"title,omitempty"`
+	ThumbnailWidth  int    `json:"thumbnail_width,omitempty"`
+	Height          int    `json:"height,omitempty"`
+	Width           int    `json:"width,omitempty"`
+	ProviderName    string `json:"provider_name,omitempty"`
+	ThumbnailURL    string `json:"thumbnail_url,omitempty"`
+	ThumbnailHeight int    `json:"thumbnail_height,omitempty"`
+}
+
+// Media holds all the media metadata.
+type Media struct {
+	Type   string `json:"type,omitempty"`
+	OEmbed OEmbed `json:"oembed,omitempty"`
+}
+
+// MediaMetadata is the media metadata of a Post.
+type MediaMetadata map[string]MediaData
+
 // Post is a submitted post on Reddit.
 type Post struct {
 	ID      string     `json:"id,omitempty"`
@@ -566,7 +588,9 @@ type Post struct {
 
 	GalleryData GalleryData `json:"gallery_data,omitempty"`
 
-	MediaMetadata map[string]MediaData `json:"media_metadata,omitempty"`
+	MediaMetadata MediaMetadata `json:"media_metadata,omitempty"`
+
+	Media Media `json:"media,omitempty"`
 
 	Score            int     `json:"score"`
 	UpvoteRatio      float32 `json:"upvote_ratio"`

--- a/reddit/things.go
+++ b/reddit/things.go
@@ -518,31 +518,35 @@ type More struct {
 	Children []string `json:"children"`
 }
 
+// GalleryMedia holds the media metadata.
 type GalleryMedia struct {
-	ID int64 `json:"id,omitempty"`
+	ID      int64  `json:"id,omitempty"`
 	MediaID string `json:"media_id,omitempty"`
 }
 
-// GalleryData Holds information to retrieve gallery items.
+// GalleryData holds information used to retrieve gallery items.
 type GalleryData struct {
 	Items []GalleryMedia `json:"items,omitempty"`
 }
 
-type mediaProperties struct {
-	URL string `json:"u"`
-	Width int64 `json:"x"`
-	Height int64 `json:"y"`
+// MediaProperties is a media and its properties.
+type MediaProperties struct {
+	URL    string `json:"u"`
+	Width  int64  `json:"x"`
+	Height int64  `json:"y"`
 }
 
+// MediaData holds all the media in a Post.
 type MediaData struct {
-	Type string `json:"e"`
-	ID string `json:"id"`
-	MIME string `json:"m"`
-	O []mediaProperties `json:"o"`  // I think this one holds the blurred preview
-	P []mediaProperties `json:"p"` //  This one all the previews ?
-	S mediaProperties `json:"s"` // The biggest preview ???
-	Status string `json:"status"`
+	Type   string            `json:"e"`
+	ID     string            `json:"id"`
+	MIME   string            `json:"m"`
+	O      []MediaProperties `json:"o"` // I think this one holds the blurred preview
+	P      []MediaProperties `json:"p"` //  This one all the previews ?
+	S      MediaProperties   `json:"s"` // The biggest preview ???
+	Status string            `json:"status"`
 }
+
 // Post is a submitted post on Reddit.
 type Post struct {
 	ID      string     `json:"id,omitempty"`

--- a/reddit/things.go
+++ b/reddit/things.go
@@ -518,6 +518,15 @@ type More struct {
 	Children []string `json:"children"`
 }
 
+type GalleryMedia struct {
+	ID int64 `json:"id,omitempty"`
+	MediaID string `json:"media_id,omitempty"`
+}
+// Holds information to retrieve gallery items.
+type GalleryData struct {
+	Items []GalleryMedia `json:"items,omitempty"`
+}
+
 // Post is a submitted post on Reddit.
 type Post struct {
 	ID      string     `json:"id,omitempty"`
@@ -534,6 +543,8 @@ type Post struct {
 	// Indicates if you've upvoted/downvoted (true/false).
 	// If neither, it will be nil.
 	Likes *bool `json:"likes"`
+
+	GalleryData GalleryData `json:"gallery_data,omitempty"`
 
 	Score            int     `json:"score"`
 	UpvoteRatio      float32 `json:"upvote_ratio"`

--- a/reddit/things.go
+++ b/reddit/things.go
@@ -522,11 +522,27 @@ type GalleryMedia struct {
 	ID int64 `json:"id,omitempty"`
 	MediaID string `json:"media_id,omitempty"`
 }
-// Holds information to retrieve gallery items.
+
+// GalleryData Holds information to retrieve gallery items.
 type GalleryData struct {
 	Items []GalleryMedia `json:"items,omitempty"`
 }
 
+type mediaProperties struct {
+	URL string `json:"u"`
+	Width int64 `json:"x"`
+	Height int64 `json:"y"`
+}
+
+type MediaData struct {
+	Type string `json:"e"`
+	ID string `json:"id"`
+	MIME string `json:"m"`
+	O []mediaProperties `json:"o"`  // I think this one holds the blurred preview
+	P []mediaProperties `json:"p"` //  This one all the previews ?
+	S mediaProperties `json:"s"` // The biggest preview ???
+	Status string `json:"status"`
+}
 // Post is a submitted post on Reddit.
 type Post struct {
 	ID      string     `json:"id,omitempty"`
@@ -545,6 +561,8 @@ type Post struct {
 	Likes *bool `json:"likes"`
 
 	GalleryData GalleryData `json:"gallery_data,omitempty"`
+
+	MediaMetadata map[string]MediaData `json:"media_metadata,omitempty"`
 
 	Score            int     `json:"score"`
 	UpvoteRatio      float32 `json:"upvote_ratio"`


### PR DESCRIPTION
Changelog:

- Added structs to things.go to support the deserialization of `media_metadata` and `gallery_data` into MediaMetadata and GalleryData.
- Allow the use of the parameter `raw_json=1` so instead of getting `&lt;, &gt;, and &amp;,` we get: <, >, and &.