### PR TITLE
Add support for Application Only OAuth

### DIFF
--- a/reddit/reddit-options.go
+++ b/reddit/reddit-options.go
@@ -55,6 +55,16 @@ func WithTokenURL(u string) Opt {
 	}
 }
 
+// WithApplicationOnlyOAuth sets authentication flow to "Application Only OAuth".
+// Only ID and Secret are required to be set in client. Username and Password are ignored.
+// The flow is described here: https://github.com/reddit-archive/reddit/wiki/OAuth2#application-only-oauth
+func WithApplicationOnlyOAuth(o bool) Opt {
+	return func(c *Client) error {
+		c.applicationOnlyOAuth = o
+		return nil
+	}
+}
+
 // FromEnv configures the client with values from environment variables.
 // Supported environment variables:
 // GO_REDDIT_CLIENT_ID to set the client's id.

--- a/reddit/reddit-options_test.go
+++ b/reddit/reddit-options_test.go
@@ -1,13 +1,17 @@
 package reddit
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 func TestWithHTTPClient(t *testing.T) {
@@ -50,6 +54,28 @@ func TestWithTokenURL(t *testing.T) {
 	c, err = NewClient(Credentials{}, WithTokenURL(tokenURL))
 	require.NoError(t, err)
 	require.Equal(t, tokenURL, c.TokenURL.String())
+}
+
+type RequestInterceptor struct {
+	interceptedBody string
+}
+
+func (t *RequestInterceptor) RoundTrip(r *http.Request) (*http.Response, error) {
+	requestBody, _ := ioutil.ReadAll(r.Body)
+	t.interceptedBody = string(requestBody)
+	var body bytes.Buffer
+	body.WriteString(`{"access_token": "foobar", "expires_in": 3600, "scope": "*", "token_type": "bearer"}`)
+	return &http.Response{Status: "200 OK", StatusCode: 200, Body: io.NopCloser(&body)}, nil
+}
+
+func TestWithApplicationOnlyOAuth(t *testing.T) {
+	requestInterceptor := &RequestInterceptor{}
+	c, err := NewClient(Credentials{ID: "id", Secret: "secret"}, WithApplicationOnlyOAuth(true), WithHTTPClient(&http.Client{Transport: requestInterceptor}))
+	require.NoError(t, err)
+	token, err := c.client.Transport.(*oauth2.Transport).Source.Token()
+	require.NoError(t, err)
+	require.Equal(t, token.AccessToken, "foobar")
+	require.Equal(t, "grant_type=client_credentials", requestInterceptor.interceptedBody)
 }
 
 func TestFromEnv(t *testing.T) {

--- a/reddit/reddit.go
+++ b/reddit/reddit.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -96,7 +95,7 @@ type Client struct {
 	Widget     *WidgetService
 	Wiki       *WikiService
 
-	oauth2Transport *oauth2.Transport
+	applicationOnlyOAuth bool
 
 	onRequestCompleted RequestCompletionCallback
 }


### PR DESCRIPTION
This PR implements Application Only OAuth (also known as "two-legged oauth").

This is NOT a breaking change and is fully backwards-compatible. Default behavior is unaffected.

This flow is activated with `WithApplicationOnlyOAuth(o bool)` option:
- `o == true`: oauthTransport uses `"golang.org/x/oauth2/clientcredentials"`
- `o == false`: oauthTransport uses `"golang.org/x/oauth2"` (default behavior)

See #18 for discussion: https://github.com/vartanbeno/go-reddit/issues/18#issuecomment-890094080

Usage example:

```go
package main

import (
	"context"
	"fmt"

	"github.com/and3rson/go-reddit/v2/reddit"
)

func main() {
	client, err := reddit.NewClient(reddit.Credentials{
		ID:     "your_client_id",
		Secret: "your_client_secret",
	}, reddit.WithUserAgent("my-application"), reddit.WithApplicationOnlyOAuth(true))
	if err != nil {
		panic(err)
	}
	posts, err := client.Subreddit.TopPosts(context.Background(), "funny", &reddit.ListPostOptions{})
	if err != nil {
		panic(err)
	}
	fmt.Println(posts)
}

```

Unit test included.