### PR TITLE
Add a limit in the call from listings by_id based on the number of IDs passed in

### DIFF
--- a/reddit/listings.go
+++ b/reddit/listings.go
@@ -32,7 +32,9 @@ func (s *ListingsService) Get(ctx context.Context, ids ...string) ([]*Post, []*C
 // GetPosts returns posts from their full IDs.
 func (s *ListingsService) GetPosts(ctx context.Context, ids ...string) ([]*Post, *Response, error) {
 	path := fmt.Sprintf("by_id/%s", strings.Join(ids, ","))
-	l, resp, err := s.client.getListing(ctx, path, nil)
+	l, resp, err := s.client.getListing(ctx, path, ListOptions{
+		Limit: len(ids),
+	})
 	if err != nil {
 		return nil, resp, err
 	}


### PR DESCRIPTION
The API allows 100 but the response is truncated server-side by the default limit parameter of 25.